### PR TITLE
modify ansible_distribution

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 - include: debian.yml
   when: ansible_distribution == "Debian" or ansible_distribution == "Ubuntu"
 - include: centos.yml
-  when: ansible_distribution == "Centos" or ansible_distribution == "Red Hat Enterprise Linux"
+  when: ansible_distribution == "CentOS" or ansible_distribution == "Red Hat Enterprise Linux"
 
 - name: update config
   template: src=mackerel-agent.conf.j2 dest=/etc/mackerel-agent/mackerel-agent.conf


### PR DESCRIPTION
I think ansible_distribution of centos is "CentOS" not "Centos".
In fact, in CentOS7 ansible_distribution is "CentOS".