### PR TITLE
Add "include" to conf template

### DIFF
--- a/templates/mackerel-agent.conf.j2
+++ b/templates/mackerel-agent.conf.j2
@@ -17,6 +17,10 @@ roles = [
 ]
 {% endif %}
 
+{% if mackerel_agent_include is defined %}
+include = "{{ mackerel_agent_include }}"
+{% endif %}
+
 {% if mackerel_agent_plugins is defined %}
 {% for key, command in mackerel_agent_plugins.items() %}
 [plugin.metrics.{{ key }}]


### PR DESCRIPTION
Add "include" section to mackerel-agent.conf template.
It enables to add free customization.