### PR TITLE
Add installation plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ mackerel_agent_root: "/var/lib/mackerel-agent"
 mackerel_agent_roles:
                  - "My-Service:app"
                  - "Another-Service:db"
+                 
+# optional 
+mackerel_use_plugins: yes # default: no
 mackerel_agent_plugins:
                  jvm: "/usr/local/bin/mackerel-plugin-jvm -javaname=NettyServer"
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,4 @@ mackerel_agent_apikey: "yourapikey"
 #                 - "Another-Service:db"
 # mackerel_agent_plugins:
 #                 jvm: "/usr/local/bin/mackerel-plugin-jvm -javaname=NettyServer"
+mackerel_use_plugins: no

--- a/tasks/centos.yml
+++ b/tasks/centos.yml
@@ -9,7 +9,7 @@
   yum: name=mackerel-agent state=latest
 
 - name: install mackerel-agent-plugins
-  yum: name=mackerel_agent_plugins state=latest
+  yum: name=mackerel-agent-plugins state=latest
   when: mackerel_use_plugins
   notify: 
     - restart mackerel-agent

--- a/tasks/centos.yml
+++ b/tasks/centos.yml
@@ -8,3 +8,9 @@
 - name: install mackerel-agent
   yum: name=mackerel-agent state=latest
 
+- name: install mackerel-agent-plugins
+  yum: name=mackerel_agent_plugins state=latest
+  when: mackerel_use_plugins
+  notify: 
+    - restart mackerel-agent
+

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -15,3 +15,13 @@
   notify:
     - restart mackerel-agent
 
+- name: install mackerel-agent-plugins
+  apt: 
+    name: mackerel_agent_plugins 
+    state: latest
+    update_cache: yes
+    force: yes
+    dpkg_options: 'force-confdef,force-confold'
+  when: mackerel_use_plugins
+  notify:
+    - restart mackerel-agent

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -17,7 +17,7 @@
 
 - name: install mackerel-agent-plugins
   apt: 
-    name: mackerel_agent_plugins 
+    name: mackerel-agent-plugins 
     state: latest
     update_cache: yes
     force: yes


### PR DESCRIPTION
The current version of this role don't install mackerel-agent-plugins.
But the role can write settings of plugins.

Users need to write installation of makcerel-agent-plugins.
Therefore I add installation task of plugins.
