### PR TITLE
Enable to edit display-name from role variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ mackerel_agent_root: "/var/lib/mackerel-agent"
 mackerel_agent_roles:
                  - "My-Service:app"
                  - "Another-Service:db"
-                 
+mackerel_agent_display_name: "My host"
+
 # optional 
 mackerel_use_plugins: yes # default: no
 mackerel_agent_plugins:

--- a/templates/mackerel-agent.conf.j2
+++ b/templates/mackerel-agent.conf.j2
@@ -8,6 +8,9 @@ root = "{{ mackerel_agent_root }}"
 {% if mackerel_agent_verbose is defined %}
 verbose = {% if mackerel_agent_verbose -%} true {% else -%} false {%- endif %}
 {% endif %}
+{% if mackerel_agent_display_name is defined %}
+display_name = "{{ mackerel_agent_display_name }}"
+{% endif %}
 
 {% if mackerel_agent_roles is defined %}
 roles = [


### PR DESCRIPTION
I want to edit display name when installing mackerel-agent by ansible.

This PR is able to change display_name value from playbook.