### PR TITLE
Add mackerel_agent_start_on_setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ mackerel_agent_plugins:
 
 mackerel_check_plugins:
                  check_cron: "/usr/local/bin/check-procs -p crond"
+mackerel_agent_start_on_setup: yes # default: yes
 ```
 
 Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,3 +11,4 @@ mackerel_agent_apikey: "yourapikey"
 # mackerel_check_plugins:
 #                 check_cron: "/usr/local/bin/check-procs -p crond"
 mackerel_use_plugins: no
+mackerel_agent_start_on_setup: yes

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,4 @@
 ---
 - name: restart mackerel-agent
   service: name=mackerel-agent state=restarted
+  when: mackerel_agent_start_on_setup

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,3 +14,4 @@
 
 - name: start mackerel-agent
   service: name=mackerel-agent state=started
+  when: mackerel_agent_start_on_setup


### PR DESCRIPTION
Add mackerel_agent_start_on_setup for creating static image (like AMI).