### PR TITLE
Change ansible galaxy link to current role

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,4 +5,4 @@ How to release new version
 1. `git commit -m "Bump version x.x.x"`
 1. `git tag vx.x.x`
 1. `git push origin master && git push --tags`
-1. See  https://galaxy.ansible.com/mackerel/mackerel-agent/
+1. See  https://galaxy.ansible.com/mackerelio/mackerel-agent/


### PR DESCRIPTION
mackerel-agent's role name in Ansible Galaxy was mackerel.mackerel-agent before.  But role name has been changed to mackerelio.mackerel-agent when I tried Re-import.

So I changed ansible galaxy link in RELEASE.md to current role mackerelio.mackerel-agent