### PR TITLE
Allow to specify options for check plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,15 @@ mackerel_agent_apikey: "yourapikey"
 mackerel_agent_pidfile: "/var/run/mackerel-agent.pid"
 mackerel_agent_root: "/var/lib/mackerel-agent"
 mackerel_agent_roles:
-                 - "My-Service:app"
-                 - "Another-Service:db"
+  - "My-Service:app"
+  - "Another-Service:db"
 mackerel_agent_display_name: "My host"
 mackerel_use_plugins: yes # default: no
 mackerel_agent_plugins:
-                 jvm: "/usr/local/bin/mackerel-plugin-jvm -javaname=NettyServer"
+  jvm: "/usr/local/bin/mackerel-plugin-jvm -javaname=NettyServer"
 
 mackerel_check_plugins:
-                 check_cron: "/usr/local/bin/check-procs -p crond"
-mackerel_agent_start_on_setup: yes # default: yes
+  check_cron: "/usr/local/bin/check-procs -p crond"
 ```
 
 Example Playbook
@@ -41,14 +40,14 @@ Example Playbook
 
 Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
 
-```yml 
+```yml
 - 
   hosts: Hatena-Antenna2_backend
   vars:
     - mackerel_agent_apikey: "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
     - mackerel_agent_roles:
-          - "My-Service:app"
-          - "Another-Service:db"
+      - "My-Service:app"
+      - "Another-Service:db"
   roles:
     - mackerel-agent
 ```

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ mackerel_agent_plugins:
 
 mackerel_check_plugins:
   check_cron: "/usr/local/bin/check-procs -p crond"
+  uptime:
+    command: "check-uptime --warning-under=600 --critical-under=120"
+    notification_interval: 10
+    max_check_attempts: 3
+    check_interval: 5
+    prevent_alert_auto_close: true
 ```
 
 Example Playbook

--- a/templates/mackerel-agent.conf.j2
+++ b/templates/mackerel-agent.conf.j2
@@ -32,8 +32,26 @@ command = "{{ command }}"
 {% endif %}
 
 {% if mackerel_check_plugins is defined %}
-{% for key, command in mackerel_check_plugins.items() %}
+{% for key, value in mackerel_check_plugins.items() %}
 [plugin.checks.{{ key }}]
-command = "{{ command }}"
+{% if value.command is defined %}
+command = "{{ value.command }}"
+
+{% if value.notification_interval is defined %}
+notification_interval = {{ value.notification_interval }}
+{% endif %}
+{% if value.max_check_attempts is defined %}
+max_check_attempts = {{ value.max_check_attempts }}
+{% endif %}
+{% if value.check_interval is defined %}
+check_interval = {{ value.check_interval }}
+{% endif %}
+{% if value.prevent_alert_auto_close is defined %}
+prevent_alert_auto_close = {{ value.prevent_alert_auto_close | bool | lower }}
+{% endif %}
+
+{% else %}
+command = "{{ value }}"
+{% endif %}
 {% endfor %}
 {% endif %}

--- a/templates/mackerel-agent.conf.j2
+++ b/templates/mackerel-agent.conf.j2
@@ -50,8 +50,8 @@ check_interval = {{ value.check_interval }}
 prevent_alert_auto_close = {{ value.prevent_alert_auto_close | bool | lower }}
 {% endif %}
 
-{% else %}
+{% else %}{# if value.command is defined #}
 command = "{{ value }}"
-{% endif %}
-{% endfor %}
-{% endif %}
+{% endif %}{# if value.command is defined #}
+{% endfor %}{# for key, value in mackerel_check_plugins.items() #}
+{% endif %}{# if mackerel_check_plugins is defined #}


### PR DESCRIPTION
This PR enables us to specify options for check plugin (eg: `prevent_alert_auto_close`). It also supports the original yml format like a following example:

```yml
---
-
  hosts: dev
  remote_user: ec2-user
  sudo: yes
  vars:
    - mackerel_agent_apikey: "XXXXX"
      mackerel_use_plugins: yes
      mackerel_check_plugins:
        uptime:
          command: "check-uptime --warning-under=600 --critical-under=120"
          notification_interval: 10
          prevent_alert_auto_close: true
        http: "check-http -u http://example.com"
  roles:
    - ansible-mackerel-agent
```
