### PR TITLE
Fix Mackerel plugins path to /usr/bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ mackerel_agent_roles:
 mackerel_agent_display_name: "My host"
 mackerel_use_plugins: yes # default: no
 mackerel_agent_plugins:
-  jvm: "/usr/local/bin/mackerel-plugin-jvm -javaname=NettyServer"
+  jvm: "/usr/bin/mackerel-plugin-jvm -javaname=NettyServer"
 
 mackerel_check_plugins:
-  check_cron: "/usr/local/bin/check-procs -p crond"
+  check_cron: "/usr/bin/check-procs -p crond"
   uptime:
     command: "check-uptime --warning-under=600 --critical-under=120"
     notification_interval: 10

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,8 +7,8 @@ mackerel_agent_apikey: "yourapikey"
 #                 - "My-Service:app"
 #                 - "Another-Service:db"
 # mackerel_agent_plugins:
-#                 jvm: "/usr/local/bin/mackerel-plugin-jvm -javaname=NettyServer"
+#                 jvm: "/usr/bin/mackerel-plugin-jvm -javaname=NettyServer"
 # mackerel_check_plugins:
-#                 check_cron: "/usr/local/bin/check-procs -p crond"
+#                 check_cron: "/usr/bin/check-procs -p crond"
 mackerel_use_plugins: no
 mackerel_agent_start_on_setup: yes


### PR DESCRIPTION
The installation path of mackerel-agent-plugins has been changed after 0.19.4.
https://mackerel.io/ja/blog/entry/weekly/20160428

Follow this change, please 🙇 