### PR TITLE
add "arch=amd64" to apt v2 repository setting

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -15,7 +15,7 @@
         (ansible_distribution == "Ubuntu" and ansible_distribution_version|float < 16.04)
 
 - name: add repository 'mackerel' v2
-  apt_repository: repo='deb http://apt.mackerel.io/v2/ mackerel contrib' state=present update_cache=yes
+  apt_repository: repo='deb [arch=amd64] http://apt.mackerel.io/v2/ mackerel contrib' state=present update_cache=yes
   when: (ansible_distribution == "Debian" and ansible_distribution_major_version|int >= 8) or
         (ansible_distribution == "Ubuntu" and ansible_distribution_version|float >= 16.04)
 


### PR DESCRIPTION
For supressing notice mesasge at `apt update`.

e.g. `N: Skipping acquire of configured file 'contrib/binary-i386/Packages' as repository 'http://apt.mackerel.io/v2 mackerel InRelease' doesn't support architecture 'i386'`