### PR TITLE
Add tasks for install mkr command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ mackerel_agent_roles:
   - "Another-Service:db"
 mackerel_agent_display_name: "My host"
 mackerel_use_plugins: yes # default: no
+mackerel_install_mkr: yes # default: no
 mackerel_agent_plugins:
   jvm: "/usr/bin/mackerel-plugin-jvm -javaname=NettyServer"
 mackerel_agent_include: "/etc/mackerel-agent/conf.d/*.conf"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,4 +12,5 @@ mackerel_agent_apikey: "yourapikey"
 # mackerel_check_plugins:
 #                 check_cron: "/usr/bin/check-procs -p crond"
 mackerel_use_plugins: no
+mackerel_install_mkr: no
 mackerel_agent_start_on_setup: yes

--- a/tasks/amazonlinux.yml
+++ b/tasks/amazonlinux.yml
@@ -42,7 +42,7 @@
     name: mackerel-agent-plugins
     state: latest
   when: mackerel_use_plugins
-  notify: 
+  notify:
     - restart mackerel-agent
 
 - name: install mackerel-check-plugins
@@ -50,6 +50,11 @@
     name: mackerel-check-plugins
     state: latest
   when: mackerel_use_plugins
-  notify: 
+  notify:
     - restart mackerel-agent
 
+- name: install mkr
+  yum:
+    name: mkr
+    state: latest
+  when: mackerel_install_mkr

--- a/tasks/centos.yml
+++ b/tasks/centos.yml
@@ -37,14 +37,19 @@
     name: mackerel-agent-plugins
     state: latest
   when: mackerel_use_plugins
-  notify: 
+  notify:
     - restart mackerel-agent
-    
+
 - name: install mackerel-check-plugins
   yum:
     name: mackerel-check-plugins
     state: latest
   when: mackerel_use_plugins
-  notify: 
+  notify:
     - restart mackerel-agent
 
+- name: install mkr
+  yum:
+    name: mkr
+    state: latest
+  when: mackerel_install_mkr

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -40,8 +40,8 @@
     - restart mackerel-agent
 
 - name: install mackerel-agent-plugins
-  apt: 
-    name: mackerel-agent-plugins 
+  apt:
+    name: mackerel-agent-plugins
     state: latest
     update_cache: yes
     force: yes
@@ -51,8 +51,8 @@
     - restart mackerel-agent
 
 - name: install mackerel-check-plugins
-  apt: 
-    name: mackerel-check-plugins 
+  apt:
+    name: mackerel-check-plugins
     state: latest
     update_cache: yes
     force: yes
@@ -60,3 +60,12 @@
   when: mackerel_use_plugins
   notify:
     - restart mackerel-agent
+
+- name: install mkr
+  apt:
+    name: mkr
+    state: latest
+    update_cache: yes
+    force: yes
+    dpkg_options: 'force-confdef,force-confold'
+  when: mackerel_install_mkr


### PR DESCRIPTION
This PR allows for users to install [mkr command](https://github.com/mackerelio/mkr).
Users can choose about either to install the command or not using role variable.