### PR TITLE
Enforce English response

### DIFF
--- a/tasks/amazonlinux.yml
+++ b/tasks/amazonlinux.yml
@@ -1,6 +1,6 @@
 ---
 - name: check amazon linux 2
-  shell: yum info installed system-release | awk '/^Release/ { print $3 }' | grep -q 'amzn2'
+  shell: LANG=C yum info installed system-release | awk '/^Release/ { print $3 }' | grep -q 'amzn2'
   ignore_errors: True
   register: check_al2
 


### PR DESCRIPTION
This PR enforce `yum info` to response in English and it removes the difference depending on the language environment .

fix: #24 