### PR TITLE
add arm64 arch only for apt v2 repository

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -23,7 +23,7 @@
 
 - name: add repository 'mackerel' v2
   apt_repository:
-    repo: 'deb [arch=amd64] http://apt.mackerel.io/v2/ mackerel contrib'
+    repo: 'deb [arch=amd64,arm64] http://apt.mackerel.io/v2/ mackerel contrib'
     state: present
     update_cache: yes
   when: (ansible_distribution == "Debian" and ansible_distribution_major_version|int >= 8) or


### PR DESCRIPTION
I added new architecture target to find Arm64 packages.

This can only be available for v2 repository.