### PR TITLE
changed  => ok when Amazon Linux 2 checking

### DIFF
--- a/tasks/amazonlinux.yml
+++ b/tasks/amazonlinux.yml
@@ -4,7 +4,7 @@
   ignore_errors: True
   register: check_al2
   check_mode: no
-  changed_when: False
+  changed_when: no
 
 - name: import mackerel GPG key
   rpm_key:

--- a/tasks/amazonlinux.yml
+++ b/tasks/amazonlinux.yml
@@ -4,6 +4,7 @@
   ignore_errors: True
   register: check_al2
   check_mode: no
+  changed_when: False
 
 - name: import mackerel GPG key
   rpm_key:


### PR DESCRIPTION
Current behavior is as follows:

```
TASK [mackerelio.mackerel-agent : check amazon linux 2] **************************************************************************************************
changed: [lp-web-al2-prod-001]
```

When the OS is Amazon Linux 2, it always displays `changed`.

This task changes nothing, so the message `changed:` should be suppressed.