### PR TITLE
Change include condition for RHEL os family.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
   when: ansible_distribution == "Debian" or ansible_distribution == "Ubuntu"
 
 - include: centos.yml
-  when: (ansible_distribution == "CentOS" or ansible_distribution == "Red Hat Enterprise Linux" or ansible_pkg_mgr == "yum") and ansible_distribution != "Amazon"
+  when: ansible_os_family == "RedHat" and ansible_distribution != "Amazon"
 
 - include: amazonlinux.yml
   when: ansible_distribution == "Amazon"


### PR DESCRIPTION
On Red Hat Enterprise Linux 8, ansible_pkg_mgr is detected as dnf. Therefore, role does not work.

So I submitted this pull request.
