### PR TITLE
change include to include_tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
-- include: debian.yml
+- include_tasks: debian.yml
   when: ansible_distribution == "Debian" or ansible_distribution == "Ubuntu"
 
-- include: centos.yml
+- include_tasks: centos.yml
   when: ansible_os_family == "RedHat" and ansible_distribution != "Amazon"
 
-- include: amazonlinux.yml
+- include_tasks: amazonlinux.yml
   when: ansible_distribution == "Amazon"
 
 - name: check config directory


### PR DESCRIPTION
As `include` is deprecated, I got following error on ansible-playbook [core 2.16.0]

> ERROR! [DEPRECATED]: ansible.builtin.include has been removed. Use include_tasks or import_tasks instead. This feature was removed from ansible-core in a release after 2023-05-16. Please update your playbooks.
