### PR TITLE
raise minimum ansible version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ An Ansible role for installing mackerel-agent and official plugins.
 Requirements & Dependencies
 ---------------------------
 
-- Tested on Ansible 1.8.2 or higher
+- Tested on Ansible 2.4 or higher
 
 Role Variables
 --------------

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,21 +4,17 @@ galaxy_info:
   description: Install mackerel agent
   company: Hatena Co., Ltd.
   license: Apache2
-  min_ansible_version: 1.2
+  min_ansible_version: 2.4
   platforms:
   - name: EL
     versions:
-      - 7
-      - 6
+    - all
   - name: Ubuntu
     versions:
-    - trusty
-    - xenial
+    - all
   - name: Debian
     versions:
-    - wheezy
-    - jessie
-    - stretch
+    - all
   categories:
     - monitoring
 dependencies: []


### PR DESCRIPTION
By #38, we are to use `import-task` module. That module was provided in ansible version 2.4.