### PR TITLE
s/categories/galaxy_tags/

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,6 +15,6 @@ galaxy_info:
   - name: Debian
     versions:
     - all
-  categories:
+  galaxy_tags:
     - monitoring
 dependencies: []


### PR DESCRIPTION
A key `categories` in meta/main.yml is obsolete. According to [this meta/main.yml example](https://docs.ansible.com/ansible/latest/galaxy/user_guide.html#using-meta-main-yml), it seems to have changed into `galaxy_tags`.

When I tried importing this role, I got a following error.
``` console
Role loading failed! unknown field in galaxy_info

Traceback (most recent call last):
  File "/venv/lib64/python3.11/site-packages/galaxy_importer/schema.py", line 532, in parse
    galaxy_info = LegacyGalaxyInfo(**metadata["galaxy_info"])
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: LegacyGalaxyInfo.__init__() got an unexpected keyword argument 'categories'
```

I have not found any sources about this change.